### PR TITLE
Changed default encoding to UTF-8

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,4 @@ pygments: false
 sass:
   syntax: scss        # scss|sass
   style:  compressed  # nested|expanded|compact|compressed
+encoding: utf-8


### PR DESCRIPTION
For me Jekyll 1.5 reports a lot of encoding errors because the content is in UTF-8. 
